### PR TITLE
Add `set_summary`

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,12 @@ Sets an output parameter.
 
 Sets an environment variable for use in later steps.
 
+### Set summary
+
+**Signature**: `def set_summary(value)`
+
+Sets an environment variable to display as job summary.
+
 ### Debug
 
 **Signature**: `debug(message)`

--- a/dist/util.py
+++ b/dist/util.py
@@ -20,6 +20,11 @@ def set_env(name, value):
         print(f"{name}={_escape_data(value)}", file=env)
 
 
+def set_summary(value):
+    with open(os.getenv("GITHUB_STEP_SUMMARY"), "a") as env:
+        print(value, file=env)
+
+
 def debug(message):
     print(f"::debug::{_escape_data(message)}")
 


### PR DESCRIPTION
Hi.

This PR adds a utility function `set_summary` that allows to set the job summary.
References for job summaries are [here](https://github.blog/2022-05-09-supercharging-github-actions-with-job-summaries/) and [here](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#adding-a-job-summary).

I've already tested the function (manually, i.e. defining it in the `script`) in https://github.com/python-telegram-bot/python-telegram-bot/pull/3508.

Let me know what you think :)